### PR TITLE
Add package.json so plugin can be submitted to NPM

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Modified by [Samer Albahra](https://twitter.com/salbahra) and Tom Krones. Origin
 1. [Description](#1-description)
 2. [Installation](#2-installation)
     2. [Automatically (CLI / Plugman)](#automatically-cli--plugman)
-    2. [Manually](#manually)3. [Usage](#3-usage)
+    2. [Manually](#manually)
+3. [Usage](#3-usage)
 4. [License](#4-license)
 
 ## 1. Description

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Allows your app to keep on playing audio when it's in the background.
 ## 2. Installation
 
 ### Automatically (CLI / Plugman)
--Compatible with [Cordova Plugman](https://github.com/apache/cordova-plugman), compatible with [PhoneGap 3.0 CLI](http://docs.phonegap.com/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface_add_features), here's how it works with the CLI (backup your project first!):
+Compatible with [Cordova Plugman](https://github.com/apache/cordova-plugman), compatible with [PhoneGap 3.0 CLI](http://docs.phonegap.com/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface_add_features), here's how it works with the CLI (backup your project first!):
 
 ```
 $ cordova plugin add cordova-plugin-ignore-mute-switch

--- a/README.md
+++ b/README.md
@@ -1,14 +1,11 @@
 
 # Ignore Mute Switch - a Cordova Plugin
-modified by [Tom Krones]
-originally by [Eddy Verbruggen](http://twitter.com/eddyverbruggen)
+Modified by [Samer Albahra](https://twitter.com/salbahra) and Tom Krones. Originally by [Eddy Verbruggen](http://twitter.com/eddyverbruggen)
 
-## 0. Index
+## Index
 
 1. [Description](#1-description)
 2. [Installation](#2-installation)
-    2. [Automatically (CLI / Plugman)](#automatically-cli--plugman)
-    2. [Manually](#manually)
 3. [Usage](#3-usage)
 4. [License](#4-license)
 
@@ -16,36 +13,11 @@ originally by [Eddy Verbruggen](http://twitter.com/eddyverbruggen)
 
 Allows your app to keep on playing audio when it's in the background.
 
-* Compatible with [Cordova Plugman](https://github.com/apache/cordova-plugman).
 * For iOS only.
 
 ## 2. Installation
 
-### Automatically (CLI / Plugman)
-Compatible with [Cordova Plugman](https://github.com/apache/cordova-plugman), compatible with [PhoneGap 3.0 CLI](http://docs.phonegap.com/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface_add_features), here's how it works with the CLI (backup your project first!):
-
-```
-$ phonegap local plugin add https://github.com/wootwoot1234/cordova-plugin-ignore-mute-switch.git
-```
-or
-```
-$ cordova plugin add https://github.com/wootwoot1234/cordova-plugin-ignore-mute-switch
-$ cordova prepare
-```
-
-### Manually
-
-1\. Add the following xml to your `config.xml` in the root directory of your `www` folder:
-```xml
-<feature name="BackgroundAudio">
-  <param name="ios-package" value="BackgroundAudio" />
-  <param name="onload" value="true" />
-</feature>
-```
-
-2\. Download the source files and copy them to your project.
-
-iOS: Copy the `.h` and `.m` files to `platforms/ios/<ProjectName>/Plugins`
+`cordova plugin add cordova-plugin-ignore-mute-switch`
 
 ## 3. Usage
 Nothing to do here as the plugin will call the required native code on load automatically :)

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Allows your app to keep on playing audio when it's in the background.
 
 ## 2. Installation
 
-`cordova plugin add cordova-plugin-ignore-mute-switch`
+`cordova plugin add cordova-plugin-ignoremuteswitch`
 
 ## 3. Usage
 Nothing to do here as the plugin will call the required native code on load automatically :)

--- a/README.md
+++ b/README.md
@@ -6,18 +6,43 @@ Modified by [Samer Albahra](https://twitter.com/salbahra) and Tom Krones. Origin
 
 1. [Description](#1-description)
 2. [Installation](#2-installation)
-3. [Usage](#3-usage)
+    2. [Automatically (CLI / Plugman)](#automatically-cli--plugman)
+    2. [Manually](#manually)3. [Usage](#3-usage)
 4. [License](#4-license)
 
 ## 1. Description
 
 Allows your app to keep on playing audio when it's in the background.
 
+* Compatible with [Cordova Plugman](https://github.com/apache/cordova-plugman).
 * For iOS only.
 
 ## 2. Installation
 
-`cordova plugin add cordova-plugin-ignoremuteswitch`
+### Automatically (CLI / Plugman)
+-Compatible with [Cordova Plugman](https://github.com/apache/cordova-plugman), compatible with [PhoneGap 3.0 CLI](http://docs.phonegap.com/en/3.0.0/guide_cli_index.md.html#The%20Command-line%20Interface_add_features), here's how it works with the CLI (backup your project first!):
+
+```
+$ cordova plugin add cordova-plugin-ignore-mute-switch
+```
+or
+```
+$ phonegap local plugin add https://github.com/wootwoot1234/cordova-plugin-ignore-mute-switch
+```
+
+### Manually
+
+1\. Add the following xml to your `config.xml` in the root directory of your `www` folder:
+```xml
+<feature name="BackgroundAudio">
+  <param name="ios-package" value="BackgroundAudio" />
+  <param name="onload" value="true" />
+</feature>
+```
+
+2\. Download the source files and copy them to your project.
+
+iOS: Copy the `.h` and `.m` files to `platforms/ios/<ProjectName>/Plugins`
 
 ## 3. Usage
 Nothing to do here as the plugin will call the required native code on load automatically :)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "cordova-plugin-ignore-mute-switch",
+  "version": "1.0.0",
+  "description": "Allows your app to play audio ignoring the mute switch.",
+  "cordova": {
+    "id": "cordova-plugin-ignore-mute-switch",
+    "platforms": [
+      "ios"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/salbahra/cordova-plugin-ignore-mute-switch.git"
+  },
+  "keywords": [
+    "ecosystem:cordova",
+    "cordova-ios"
+  ],
+  "engines": [
+    {
+      "name": "cordova",
+      "version": ">=3.0.0"
+    }
+  ],
+  "author": "Samer Albahra",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/salbahra/cordova-plugin-ignore-mute-switch/issues"
+  },
+  "homepage": "https://github.com/salbahra/cordova-plugin-ignore-mute-switch#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "cordova-plugin-ignoremuteswitch",
+  "name": "cordova-plugin-ignore-mute-switch",
   "version": "1.0.1",
   "description": "Allows your app to play audio ignoring the mute switch.",
   "cordova": {
-    "id": "cordova-plugin-ignoremuteswitch",
+    "id": "cordova-plugin-ignore-mute-switch",
     "platforms": [
       "ios"
     ]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/salbahra/cordova-plugin-ignoremuteswitch.git"
+    "url": "git+https://github.com/wootwoot1234/cordova-plugin-ignore-mute-switch.git"
   },
   "keywords": [
     "ecosystem:cordova",
@@ -25,7 +25,7 @@
   "author": "Samer Albahra",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/salbahra/cordova-plugin-ignoremuteswitch/issues"
+    "url": "https://github.com/wootwoot1234/cordova-plugin-ignore-mute-switch/issues"
   },
-  "homepage": "https://github.com/salbahra/cordova-plugin-ignoremuteswitch#readme"
+  "homepage": "https://github.com/wootwoot1234/cordova-plugin-ignore-mute-switch#readme"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-ignoremuteswitch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Allows your app to play audio ignoring the mute switch.",
   "cordova": {
     "id": "cordova-plugin-ignoremuteswitch",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
-  "name": "cordova-plugin-ignore-mute-switch",
+  "name": "cordova-plugin-ignoremuteswitch",
   "version": "1.0.0",
   "description": "Allows your app to play audio ignoring the mute switch.",
   "cordova": {
-    "id": "cordova-plugin-ignore-mute-switch",
+    "id": "cordova-plugin-ignoremuteswitch",
     "platforms": [
       "ios"
     ]
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/salbahra/cordova-plugin-ignore-mute-switch.git"
+    "url": "git+https://github.com/salbahra/cordova-plugin-ignoremuteswitch.git"
   },
   "keywords": [
     "ecosystem:cordova",
@@ -25,7 +25,7 @@
   "author": "Samer Albahra",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/salbahra/cordova-plugin-ignore-mute-switch/issues"
+    "url": "https://github.com/salbahra/cordova-plugin-ignoremuteswitch/issues"
   },
-  "homepage": "https://github.com/salbahra/cordova-plugin-ignore-mute-switch#readme"
+  "homepage": "https://github.com/salbahra/cordova-plugin-ignoremuteswitch#readme"
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova-plugin-ignoremuteswitch"
+        id="cordova-plugin-ignore-mute-switch"
         version="1.0.1">
 
   <name>BackgroundAudio</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="cordova.plugin.ignoremuteswitch"
+        id="cordova-plugin-ignoremuteswitch"
         version="1.0.0">
 
   <name>BackgroundAudio</name>

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="cordova-plugin-ignoremuteswitch"
-        version="1.0.0">
+        version="1.0.1">
 
   <name>BackgroundAudio</name>
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
-        id="nl.x-services.plugins.backgroundaudio"
+        id="cordova.plugin.ignoremuteswitch"
         version="1.0.0">
 
   <name>BackgroundAudio</name>


### PR DESCRIPTION
The readme method below which uses only the package name requires the plugin to be added to NPM (takes just a moment) and will simplify plugin install greatly (especially for remote builds).

Thank you!